### PR TITLE
Fix compilation if CPUID_SUPPORT is not defined

### DIFF
--- a/src/System/Cpuid/Basic.hs
+++ b/src/System/Cpuid/Basic.hs
@@ -44,6 +44,7 @@ import Prelude
 import Foreign
 #else
 import Data.Word
+import Data.Bits
 #endif
 
 -- * CPUID support


### PR DESCRIPTION
Otherwise .&. which is used in a few places is not available